### PR TITLE
Use latest miniconda version if Spark >= 2.2.0 

### DIFF
--- a/conda/README.MD
+++ b/conda/README.MD
@@ -61,9 +61,11 @@ CONDA_ENV_YAML=$CONDA_ENV_YAML_PATH ./install-conda-env.sh
 ### bootstrap-conda.sh
 
 `bootstrap-conda.sh` contains logic for quickly configuring and installing Miniconda across the dataproc cluster. Defaults to [`Miniconda3-latest-Linux-x86_64.sh`](https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh) package (e.g., Python 3), however, users can easily config for targeted versions via the following instance metadata keys:
-    - `MINICONDA_VARIANT`: the Python version can be `2` or `3`
-    - `MINICONDA_VER`: the Miniconda version (e.g., `4.0.5`)
+- `MINICONDA_VARIANT`: the Python version can be `2` or `3`
+- `MINICONDA_VER`: the Miniconda version (e.g., `4.0.5`)
+
 In addition, the script:
+
 - downloads and installs Miniconda to the `$HOME` directory
 - updates `$PATH`, exposing conda across all shell processes (for both interactive and batch sessions)
 - installs some useful extensions:
@@ -80,12 +82,12 @@ See the script source for more options on configuration. :)
 - detects if conda environment has already been created.
 - updates `/etc/profile` to activate the created environment at login (if needed)
 
-Note: When creating a conda environment using an environment.yml (via setting .yml path in `CONDA_ENV_YAML`), the `install-conda-env.sh` script simply *updates the **root** environment* with dependencies specified in the file (i.e., ignoring the `name:` key). This sidesteps some conda issues in `source activate`ing, while still providing all dependencies across the Dataproc cluster.
+Note: When creating a conda environment using an environment.yml (via setting .yml path in `CONDA_ENV_YAML`), the `install-conda-env.sh` script simply *updates the **root** environment* with dependencies specified in the file (i.e., ignoring the `name:` key). This sidesteps some conda issues with `source activate`, while still providing all dependencies across the Dataproc cluster.
 
 
 ## Testing Installation
 
-A quick test to ensure a correct installation of conda, we can submit jobs that collect distinct paths to the Python distribution across all Spark executors. For both local (e.g., running from dataproc cluster master node) and remote (e.g. submitting a job via the dataproc API) jobs, the result should be a list with a single path: `['/opt/conda/bin/python']`. For example
+A quick test to ensure a correct installation of conda, we can submit jobs that collect distinct paths to the Python distribution across all Spark executors. For both local (e.g., running from dataproc cluster master node) and remote (e.g. submitting a job via the dataproc API) jobs, the result should be a list with a single path: `['/opt/conda/bin/python']`. For example:
 
 
 ### Local Job Test

--- a/conda/bootstrap-conda.sh
+++ b/conda/bootstrap-conda.sh
@@ -37,11 +37,18 @@ else
     fi
     ## specify Miniconda release (e.g., MINICONDA_VERSION='4.0.5')
     if [[ -z "${MINICONDA_VERSION}" ]]; then
-        echo "MINICONDA_VERSION not set, setting ..."
-        # Pin to 4.2.12 by default until Spark default is 2.2.0.
-        # https://issues.apache.org/jira/browse/SPARK-19019
+      # Pin to 4.2.12 by default until Spark default is 2.2.0, then use latest
+      # https://issues.apache.org/jira/browse/SPARK-19019
+      MIN_SPARK_VERSION="2.2.0"
+      SPARK_VERSION=`spark-submit --version 2>&1  | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\.[0-9]\+\+\).*/\1/p' | head -n1`
+      if dpkg --compare-versions ${SPARK_VERSION} ge ${MIN_SPARK_VERSION}; then
+        echo "MINICONDA_VERSION not set, Spark version >= ${MIN_SPARK_VERSION}, setting Miniconda version to latest ..."
+        MINICONDA_VERSION='latest'
+      else
+        echo "MINICONDA_VERSION not set, Spark version < ${MIN_SPARK_VERSION}, setting Miniconda to 4.2.12 ..."
         MINICONDA_VERSION='4.2.12'
-        set "Set MINICONDA_VERSION to $MINICONDA_VERSION"
+      fi
+      set "Set MINICONDA_VERSION to $MINICONDA_VERSION"
     fi
 
     ## 0.2 Compute Miniconda version


### PR DESCRIPTION
This change checks whether Spark version is >= 2.2.0 and if so sets the Miniconda version to the latest version. If Spark is < 2.2.0 then the existing behavior is unchanged: pin Miniconda to 4.2.12

This change should resolve the following issue once merged with the main repo:
  https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/issues/149

This change also includes some formatting fixes to README.MD: the bullet points in the markdown don't render correctly on github.